### PR TITLE
Fixed social media links to open in new page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,21 +9,21 @@
       </a>
 
       <div class="social-links">
-        <a href="https://www.linkedin.com/school/mlh-fellowship/" class="links"
+        <a href="https://www.linkedin.com/school/mlh-fellowship/" class="links" target="_blank"
           ><i class="fab fa-linkedin fa-lg"></i
         ></a>
-        <a href="https://www.instagram.com/mlhacks/" class="links"
+        <a href="https://www.instagram.com/mlhacks/" class="links" target="_blank"
           ><i class="fab fa-instagram fa-lg"></i
         ></a>
         <a
           href="https://twitter.com/MLHacks?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
-          class="links"
+          class="links" target="_blank"
           ><i class="fab fa-twitter fa-lg"></i
         ></a>
-        <a href="https://www.facebook.com/MajorLeagueHacking" class="links"
+        <a href="https://www.facebook.com/MajorLeagueHacking" class="links" target="_blank"
           ><i class="fab fa-facebook fa-lg"></i
         ></a>
-        <a href="https://www.youtube.com/c/Majorleaguehacking" class="links"
+        <a href="https://www.youtube.com/c/Majorleaguehacking" class="links" target="_blank"
           ><i class="fab fa-youtube fa-lg"></i
         ></a>
       </div>


### PR DESCRIPTION
Issue: [#23](https://github.com/MLH-Fellowship/prep-portfolio-23.MAR.PREP.1/issues/23)

Previously the social media links weren't opening on a new page. This has been fixed.

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.

