### PR TITLE
Resolve #2: Add image compression action 

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yaml
+++ b/.github/workflows/calibreapp-image-actions.yaml
@@ -1,0 +1,31 @@
+name: Compress Images
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Compress Images
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For non-Pull Requests, run in compressOnly mode and we'll PR after.
+          compressOnly: ${{ github.event_name != 'pull_request' }}
+
+      - name: Create Pull Request
+        # If it's not a Pull Request then commit any changes as a new PR.
+        # Enable access permission for GitHub Action to create pull requests.
+        # For info, check https://stackoverflow.com/questions/72376229/github-actions-is-not-permitted-to-create-or-approve-pull-requests-createpullre
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Auto Compress Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
## Please, go through these steps before you submit a PR.

- [X] My Pod Leader knows I'm working on this Pull Request
- [X] I've explained what the Pull Request is adding.
- [X] I've explained why this is important.

The action easily compresses images to reduce file sizes, improve page load times, and boost website performance. It provides a quick and effortless way to optimize images, making them more suitable for web use.

The [calibreapp/image-actions@main](https://github.com/marketplace/actions/image-actions#process-pull-requests-from-forked-repositories) action used within the workflow, only works for Pull Requests from branches in the same repository as the destination branch. This is due to the fact that by default, GitHub Actions do not have permission to alter forked repositories.

To solve the above, we changed the GitHub Action to execute only on `push` events to the `main` branch and defined an additional step to create a pull request for the compressed images file whenever there's a  `push` event to the `main` branch. For this step to successfully execute, access permissions for GitHub Action to create pull requests should be enabled. For info, check https://stackoverflow.com/questions/72376229/github-actions-is-not-permitted-to-create-or-approve-pull-requests-createpullre


        

